### PR TITLE
Fix V3025

### DIFF
--- a/source/SharpFlame/Mapping/IO/Wz/WzLoader.cs
+++ b/source/SharpFlame/Mapping/IO/Wz/WzLoader.cs
@@ -1121,8 +1121,8 @@ namespace SharpFlame.Mapping.IO.Wz
                         {
                             Debugger.Break();
                             resultObject.WarningAdd(
-                                string.Format("#{0} invalid {2}: \"{3}\", got exception: {2}", iniSection.Name, iniToken.Name, iniToken.Data, ex.Message), false);
-                            logger.ErrorException(string.Format("#{0} invalid {2} \"{1}\"", iniSection.Name, iniToken.Name, iniToken.Data), ex);
+                                string.Format("#{0} invalid {1}: \"{2}\", got exception: {3}", iniSection.Name, iniToken.Name, iniToken.Data, ex.Message), false);
+                            logger.ErrorException(string.Format("#{0} invalid {1} \"{2}\"", iniSection.Name, iniToken.Name, iniToken.Data), ex);
                             invalid = true;
                         }
                     }

--- a/source/SharpFlame/Mapping/IO/Wz/WzLoader.cs
+++ b/source/SharpFlame/Mapping/IO/Wz/WzLoader.cs
@@ -1242,8 +1242,8 @@ namespace SharpFlame.Mapping.IO.Wz
                         {
                             Debugger.Break();
                             resultObject.WarningAdd(
-                                string.Format("#{0} invalid {2}: \"{3}\", got exception: {2}", iniSection.Name, iniToken.Name, iniToken.Data, ex.Message), false);
-                            logger.Warn(ex, "#{0} invalid {2} \"{1}\"", iniSection.Name, iniToken.Name, iniToken.Data);
+                                string.Format("#{0} invalid {1}: \"{2}\", got exception: {3}", iniSection.Name, iniToken.Name, iniToken.Data, ex.Message), false);
+                            logger.Warn(ex, "#{0} invalid {1} \"{2}\"", iniSection.Name, iniToken.Name, iniToken.Data);
                             invalid = true;
                         }
                     }


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio:

- Incorrect format. A different number of format items is expected while calling 'Format' function. Arguments not used: iniToken.Name. SharpFlame WzLoader.cs 1124

- Incorrect format. A different number of format items is expected while calling 'Format' function. Arguments not used: iniToken.Name. SharpFlame WzLoader.cs 1245