### PR TITLE
Fix V3118

### DIFF
--- a/source/SharpFlame/Mapping/Map.cs
+++ b/source/SharpFlame/Mapping/Map.cs
@@ -872,10 +872,10 @@ namespace SharpFlame.Mapping
             }
 
             var timeDiff = DateTime.Now - AutoSave.SavedDate;
-            if ( timeDiff.Seconds < App.SettingsManager.AutoSaveMinIntervalSeconds )
+            if ( timeDiff.TotalSeconds < App.SettingsManager.AutoSaveMinIntervalSeconds )
             {
                 logger.Debug(string.Format("No autosave, we have {0} seconds of {1}",
-                    timeDiff.Seconds, App.SettingsManager.AutoSaveMinIntervalSeconds));
+                    timeDiff.TotalSeconds, App.SettingsManager.AutoSaveMinIntervalSeconds));
                 return;
             }
 
@@ -2052,11 +2052,10 @@ namespace SharpFlame.Mapping
             var DateNow = DateTime.Now;
             var Changed = false;
 
-            A = 0;
             while ( A < Messages.Count )
             {
                 var timeDiff = DateTime.Now - Convert.ToDateTime(Messages[A].CreatedDate);
-                if ( timeDiff.Seconds >= 6 )
+                if ( timeDiff.TotalSeconds >= 6 )
                 {
                     Messages.RemoveAt(A);
                     Changed = true;


### PR DESCRIPTION
Another bug fixes from Pinguem.ru competition found with PVS-Studio:

- Seconds component of 'timeDiff' is used, which does not represent full time interval. Possibly 'TotalSeconds' value was intended instead. SharpFlame Map.cs 875

- Seconds component of 'timeDiff' is used, which does not represent full time interval. Possibly 'TotalSeconds' value was intended instead. SharpFlame Map.cs 2059